### PR TITLE
Added missing space before exit code.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -605,7 +605,7 @@ main() {
     env) command_env;;
     sign_domains) command_sign_domains;;
     revoke) command_revoke "${PARAM_REVOKECERT}";;
-    *) command_help; exit1;;
+    *) command_help; exit 1;;
   esac
 }
 


### PR DESCRIPTION
I could've sworn the script gave me an  `exit1: command not found` error at some point, but I can't reproduce it now.

In any case, here is the world's smallest bugfix.
